### PR TITLE
Remove Ethereum Sepolia Testnet details from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,6 @@ After deployment, verify on Sonic Explorer:
 npx hardhat verify --network sonicTestnet <CONTRACT_ADDRESS>
 ```
 
-## 🌐 Networks
-
-- **Ethereum Sepolia Testnet**
-  - RPC: https://rpc.sepolia.org
-  - Chain ID: 11155111
-  - Explorer: https://sepolia.etherscan.io
-  - Faucet: https://sepoliafaucet.com
-
 ## 📖 Resources
 
 - [KRNL Studio](https://krnl.xyz)


### PR DESCRIPTION
Removed network information for Ethereum Sepolia Testnet from README.